### PR TITLE
Add nuxt cache plugin

### DIFF
--- a/server/plugins/cache.ts
+++ b/server/plugins/cache.ts
@@ -1,0 +1,7 @@
+import { RenderResponse } from "nitropack"
+
+export default defineNitroPlugin((nitroApp) => {
+    nitroApp.hooks.hook('render:response', (res: RenderResponse) => {
+        res.headers['cache-control'] = `no-cache`
+    })
+})


### PR DESCRIPTION
set `Cache-Control` to 'no-cache' on initial page request to bust Cloud Front cache.