### PR TITLE
Passes indicator type to view indicator component

### DIFF
--- a/components/pages/nr7/my-country/edit/indicator-data/indicator-list.vue
+++ b/components/pages/nr7/my-country/edit/indicator-data/indicator-list.vue
@@ -26,7 +26,7 @@
                     </nr7-add-indicator-data>       
 
                     <div v-if="indicator.nationalData">
-                        <nr7-view-indicator-data :indicator-data="indicator.nationalData"></nr7-view-indicator-data>
+                        <nr7-view-indicator-data :indicator-data="indicator.nationalData" :indicator-type="indicatorType"></nr7-view-indicator-data>
                     </div>
                 </div>      
                 <div v-if="indicator.identifier?.indexOf('KMGBF-INDICATOR-BIN')>=0" >  

--- a/components/pages/nr7/my-country/edit/indicator-data/nr7-add-indicator-data.vue
+++ b/components/pages/nr7/my-country/edit/indicator-data/nr7-add-indicator-data.vue
@@ -18,7 +18,6 @@
         <CModalBody>
             <CCard>
                 <CCardBody>
-
                     <div  v-if="isLoading">
                         <km-spinner></km-spinner>
                     </div>
@@ -118,7 +117,7 @@
                                 </div>                                 
                             </template>
                             <template #review>
-                                <nr7-view-indicator-data v-if="cleanDocument.indicator" :indicator-data="cleanDocument">
+                                <nr7-view-indicator-data v-if="cleanDocument.indicator" :indicator-data="cleanDocument" :indicator-type="indicatorType">
                                 </nr7-view-indicator-data>
                             </template>
                         </km-form-workflow>
@@ -194,7 +193,7 @@
         const { data, globalDataSources, globalDescription, globalIndicatorProviders,indicator } = document.value
         return { data, globalDataSources, globalDescription, globalIndicatorProviders, indicator };        
     });
-  
+    
     const cleanDocument = computed(()=>{
         const clean = useKmStorage().cleanDocument({...document.value});
         

--- a/components/pages/nr7/my-country/edit/nr7-edit-section-III.vue
+++ b/components/pages/nr7/my-country/edit/nr7-edit-section-III.vue
@@ -159,11 +159,12 @@
                                                     <span v-if="key=='national'">{{ lstring(nationalIndicator?.value, locale) }}</span>
                                                 </label>
                                             </template>   
-                                            <template #actionButtons="{key,indicatorData, indicator}">
-                                                <nr7-add-indicator-data :indicator="indicator"  v-if="key!='binary'"
+                                            <template #actionButtons="{key,indicatorData, indicator, nationalIndicator}">
+                                                <nr7-add-indicator-data :indicator="key=='national'? nationalIndicator : indicator"  v-if="key!='binary'"
                                                         :identifier="indicatorData?.identifier" 
                                                         container=".nr7-add-indicator-data-modal"
-                                                        @on-close="onAddIndicatorDataClose">
+                                                        @on-close="onAddIndicatorDataClose"
+                                                        :indicator-type="key=='national'?'otherNationalIndicators':key">
                                                     </nr7-add-indicator-data>  
                                                 <nr7-add-binary-indicator-data :indicator="indicator"  v-if="key=='binary'"
                                                     container=".nr7-add-binary-indicator-data-modal"
@@ -259,7 +260,7 @@
     });
 
     const nationalIndicators      = computed(()=>{
-        return Object.values(nationalTargets.value).map(e=>e.nationalIndicators||[]).flat();
+        return Object.values(nationalTargets.value).map(e=>e.nationalIndicators||[]).flat().map(e=>{ return {...e, title:e.title||e.value}});
     });
     const nationalTargetsComputed = computed(()=>nationalTargets.value);
     const progressAssessmentLists = computed(()=>(thesaurusStore.getDomainTerms(THESAURUS.ASSESSMENT_PROGRESS)||[]));

--- a/components/pages/nr7/my-country/edit/nr7-edit-section-IV.vue
+++ b/components/pages/nr7/my-country/edit/nr7-edit-section-IV.vue
@@ -63,7 +63,8 @@
                                             <nr7-add-indicator-data :indicator="indicator"  v-if="key!='binary'"
                                                     :identifier="indicatorData?.identifier" 
                                                     container=".nr7-add-indicator-data-modal"
-                                                    @on-close="onAddIndicatorDataClose">
+                                                    @on-close="onAddIndicatorDataClose"                                                    
+                                                    :indicator-type="key=='national'?'otherNationalIndicators':key">
                                                 </nr7-add-indicator-data>  
                                             <nr7-add-binary-indicator-data :indicator="indicator"  v-if="key=='binary'"
                                                 container=".nr7-add-binary-indicator-data-modal"

--- a/components/pages/nr7/my-country/view/nr7-view-indicator-data.vue
+++ b/components/pages/nr7/my-country/view/nr7-view-indicator-data.vue
@@ -44,7 +44,8 @@ import type { ETerm } from '~/types/schemas/base/ETerm';
 
     const props = defineProps({
         indicatorData: { type: Object, required: true },
-        documentLocale: { type:String }
+        documentLocale: { type:String },
+        indicatorType: { type: String }
     });
 
     const thesaurusStore    = useThesaurusStore();
@@ -79,7 +80,7 @@ import type { ETerm } from '~/types/schemas/base/ETerm';
     });
 
     onMounted(async () => {
-        if (indicatorData.value.indicator) {
+        if (indicatorData.value.indicator && props.indicatorType != 'otherNationalIndicators') {            
             await thesaurusStore.loadTerm(indicatorData.value.indicator.identifier);
         }
     }); 

--- a/components/pages/nr7/my-country/view/nr7-view-target-indicators.vue
+++ b/components/pages/nr7/my-country/view/nr7-view-target-indicators.vue
@@ -15,11 +15,11 @@
 
             <div class="card-body">
                 <slot name="actionButtons" :key="key" :indicator-data="computedIndicatorsData?.[indicatorData.data?.identifier]"
-                    :indicator="indicatorData?.indicator">
+                    :indicator="indicatorData?.indicator" :national-indicator="computedNationalIndicators[indicatorData.indicator?.identifier]">
                 </slot>
                 <div v-if="key!= 'binary' && indicatorData.data">
                     <div v-if="computedIndicatorsData[indicatorData.data.identifier]">
-                        <nr7-view-indicator-data
+                        <nr7-view-indicator-data :indicator-type="key=='national'?'otherNationalIndicators': key"
                             :indicator="indicator"
                             :indicator-data="computedIndicatorsData[indicatorData.data.identifier]?.body"></nr7-view-indicator-data>
                     </div>


### PR DESCRIPTION
Passes the indicator type to the view indicator component to handle specific logic based on the type of indicator being displayed. This allows different views and functionalities to be applied based on whether the indicator is national or related to other categories.

The 'title' of national indicators is now correctly displayed.