### PR TITLE
Refines commitment linking terminology

### DIFF
--- a/i18n/en/components/controls/user-settings/auto-approve-commitments.json
+++ b/i18n/en/components/controls/user-settings/auto-approve-commitments.json
@@ -1,8 +1,8 @@
 {
-    "autoReviewCommitments": "Automatically approve and publish all future commitments that have been linked to my country",
+    "autoReviewCommitments": "Automatically publish all future commitments that have been linked to my country",
     "confirm": "Confirm",
-    "confirmYesMessage": "Are you sure you want to automatically approve and publish all future commitments that have been linked to my country?",
-    "confirmNoMessage": "Are you sure you want to stop automatically approving and publishing all future commitments?",
+    "confirmYesMessage": "Are you sure you want to automatically publish all future commitments that have been linked to my country?",
+    "confirmNoMessage": "Are you sure you want to stop automatically publishing all future commitments?",
     "processing": "Processing...",
     "error": "Error saving auto review commitments",
     "success": "Auto review commitments updated",

--- a/i18n/en/components/pages/stakeholders/commitments/country-reviews/country-review-list.json
+++ b/i18n/en/components/pages/stakeholders/commitments/country-reviews/country-review-list.json
@@ -5,7 +5,7 @@
     "updatedOn":"Updated",
     "action" : "Actions",
     "awaitingAction" : "Awaiting action",
-    "published": "Reviewed",
+    "published": "Linked",
     "returned": "Returned",
-    "autoPublished": "Auto reviewed"
+    "autoPublished": "Auto linked"
 }

--- a/i18n/en/components/pages/stakeholders/commitments/country-reviews/my-country-reviews.json
+++ b/i18n/en/components/pages/stakeholders/commitments/country-reviews/my-country-reviews.json
@@ -1,8 +1,8 @@
 {
     "awaitingAction" : "Awaiting action",
-    "published": "Reviewed",
+    "published": "Linked",
     "returned": "Returned",
-    "autoPublished": "Auto reviewed",
+    "autoPublished": "Auto linked",
     "countryReviews": "Country reviews",
     "all": "All",
     "noCountryReviews": "No country reviews found",

--- a/i18n/en/components/pages/stakeholders/commitments/view-commitment.json
+++ b/i18n/en/components/pages/stakeholders/commitments/view-commitment.json
@@ -1,6 +1,6 @@
 {
     "commitmentTitle": "Commitment",
-    "countryReviewTitle" : "Country reviews",
-    "countryReviewHelp": "The following countries have reviewed this commitment.",
-    "noCountryReviews" : "Currently there are no country reviews on this commitment."
+    "countryReviewTitle" : "Linked countries",
+    "countryReviewHelp": "The following countries are linked to this commitment.",
+    "noCountryReviews" : "Currently there are no countries linked to this commitment."
 }


### PR DESCRIPTION
Updates UI text to use "publish" instead of "approve" for auto-commitments, and "linked" instead of "reviewed" for country associations.

This improves clarity and consistency in describing the process of associating countries with commitments.