### PR TITLE
Customizes NR7 search result metadata

### DIFF
--- a/components/controls/search/record-type-search.vue
+++ b/components/controls/search/record-type-search.vue
@@ -27,8 +27,13 @@
                 </div>
 
                 <km-spinner v-if="loading" center></km-spinner>
-                <search-result v-if="documents?.length" :documents="documents"></search-result>
-
+                <search-result v-if="documents?.length" :documents="documents">
+                    <template #metadata="{document}">
+                        <slot name="metadata" :document="document"></slot>
+                    </template>
+                </search-result>
+                <pagination v-if="recordCount > 0" :recordCount="recordCount"  :recordsPerPage="recordsPerPage"
+                    :currentPage="currentPage" @on-page-change="onPageChange" @on-records-per-page-changed="onRecordsPerPageChanged"  ></pagination>
             <!-- </overlay-loading> -->
         </div>
         <CAlert color="info" class="d-flex align-items-center mt-5" 

--- a/components/controls/search/search-result-item.vue
+++ b/components/controls/search/search-result-item.vue
@@ -21,10 +21,11 @@
                     </div>
                 </CCardText>
                 <CCardText>
-                    <small class="me-2 fs-6">{{document.schema_EN_s}}</small>|
-                    <small class="me-2 fs-6">{{document.government_EN_s}}</small>|
-                    <small class="me-2 fs-6">{{formatDate(document.recDate)}}</small>
-                    
+                    <slot name="metadata" :document="document">
+                        <small class="me-2 fs-6">{{document.schema_EN_s}}</small>|
+                        <small class="me-2 fs-6" v-if="document.government_EN_s">{{document.government_EN_s}}|</small>
+                        <small class="me-2 fs-6">{{formatDate(document.recDate)}}</small>
+                    </slot>
                 </CCardText>
             </CCardBody>
         </CCard>

--- a/components/controls/search/search-result.vue
+++ b/components/controls/search/search-result.vue
@@ -1,6 +1,10 @@
 <template>
     <div v-for="document in documents" :key="document.id">
-        <search-result-item :document="document" link-target="linkTarget"></search-result-item>
+        <search-result-item :document="document" link-target="linkTarget">
+            <template #metadata="{document}">
+                <slot name="metadata" :document="document"></slot>
+            </template>
+        </search-result-item>
     </div>
 </template>
 

--- a/components/pages/nr7/nr7-list.vue
+++ b/components/pages/nr7/nr7-list.vue
@@ -2,9 +2,22 @@
     <div>
         <record-type-search :recordTypes="recordTypes"
         :show-record-type="false" :show-targets="false" :show-goals="false">
+            <template #metadata="{document}">
+                <slot name="metadata" :document="document">
+                    <small class="me-2 fs-6">{{document.schema_EN_s}}</small>|
+                    <small class="me-2 fs-6" v-if="document.government_EN_s">{{document.government_EN_s}} |</small>
+                    <small class="me-2 fs-6">
+                        <strong>{{t('publishedOn')}}</strong> {{formatDate(document.recCreationDate)}}
+                    </small>
+                    <small class="me-2 fs-6"  v-if="document.recDate!=document.recCreationDate">
+                        {{t('updated')}} {{formatDate(document.recDate)}}
+                    </small>
+                </slot>
+            </template>
         </record-type-search>
     </div>
 </template>
+<i18n src="@/i18n/dist/components/pages/nr7/nr7-list.json"></i18n>
 <script setup lang="ts">
 //@ts-nocheck
 import searchResult from '@/components/controls/search/search-result.vue';

--- a/i18n/en/components/pages/nr7/nr7-list.json
+++ b/i18n/en/components/pages/nr7/nr7-list.json
@@ -1,1 +1,4 @@
-{}
+{
+    "publishedOn": "Published on",
+    "updated": "Updated"
+}


### PR DESCRIPTION
Enables external customization of search result metadata display by introducing a dedicated slot in the `search-result` and `search-result-item` components.

The `nr7-list` component leverages this new slot to present specific metadata, including schema, a conditionally displayed government field, and detailed publication and update dates. Additionally, pagination support is added to the `record-type-search` component to improve navigation for large result sets. Includes relevant internationalization strings for new date labels.