### PR TITLE
Enables PDF caching and direct retrieval from S3

### DIFF
--- a/components/common/pdf-section.vue
+++ b/components/common/pdf-section.vue
@@ -27,6 +27,7 @@
         element : {type: String, required:true},
         title   : {type: String, required:true},
         fileName: {type: String, required:true},
+        saveToStorage: {type: Boolean, default:false},
     });
 
     const emit = defineEmits(['onPdfDocument', 'onAfterPdf', 'onBeforeGetContent',
@@ -34,6 +35,7 @@
 
     const {t}             = useI18n();
     const { $recaptcha }  = useNuxtApp();
+    const realmConf       = useRealm();
 
     const isGeneratingPdf      = ref(false);
     const userPdfHtml   = ref(null);
@@ -60,6 +62,22 @@
         emit('onPdfDocument');
         
         isGeneratingPdf.value = true;
+
+         
+        if(props.saveToStorage){
+            const s3Url = `https://s3.amazonaws.com/pdf-cache-prod/${realmConf.realm?.toLowerCase()}/${downloadFileName.value}`;
+
+            const exists = await $fetch.raw(s3Url, {
+                method: 'HEAD'
+            }).catch((e)=>{})
+            
+            if(exists?.status == 200){
+                window.open(exists.url, '_blank')
+                isGeneratingPdf.value = false;
+                return;
+            }
+        }
+
         await sleep(200);
         userPdfHtml.value = document.querySelector(props.element).innerHTML;
         await sleep(200);
@@ -87,7 +105,8 @@
                     body : { html }, 
                     params : {
                         'attachment-name' : downloadFileName.value,
-                        baseurl:baseUrl
+                        baseurl:baseUrl,
+                        saveToStorage:props.saveToStorage
                     },
                     responseType: "blob", 
                     headers:{

--- a/components/common/pdf-section.vue
+++ b/components/common/pdf-section.vue
@@ -41,7 +41,7 @@
     const userPdfHtml   = ref(null);
 
     const downloadFileName = computed(()=>{
-        const fileName = 'scbd-ort-' + (props.fileName || props.title?.trim()?.replace(/[\W_]+/gi, '-').substr(0, 50));
+        const fileName = `scbd-${realmConf.realm?.toLowerCase()}-${props.fileName || props.title?.trim()?.replace(/[\W_]+/gi, '-').substr(0, 50)}`;
 
         if(fileName.endsWith('.pdf'))
             return fileName
@@ -63,16 +63,16 @@
         
         isGeneratingPdf.value = true;
 
-         
+        const realmFileKey = `${realmConf.realm?.toLowerCase()}/${downloadFileName.value}`
         if(props.saveToStorage){
-            const s3Url = `https://s3.amazonaws.com/pdf-cache-prod/${realmConf.realm?.toLowerCase()}/${downloadFileName.value}`;
+            const s3Url = `https://s3.amazonaws.com/pdf-cache-prod/${realmFileKey}`;
 
             const exists = await $fetch.raw(s3Url, {
                 method: 'HEAD'
             }).catch((e)=>{})
             
             if(exists?.status == 200){
-                window.open(exists.url, '_blank')
+                await downloadS3File({url:exists.url})
                 isGeneratingPdf.value = false;
                 return;
             }
@@ -104,7 +104,7 @@
                     method:'POST', 
                     body : { html }, 
                     params : {
-                        'attachment-name' : downloadFileName.value,
+                        'attachment-name' : realmFileKey,
                         baseurl:baseUrl,
                         saveToStorage:props.saveToStorage
                     },
@@ -113,22 +113,7 @@
                         'x-captcha-v2-badge-token' : captchaToken
                     }
                 })
-
-                // Create a Blob from the response data
-                const buffer = await res.arrayBuffer();
-                const pdfBlob = new Blob([buffer], { type: "application/pdf" });
-
-                // Create a temporary URL for the Blob
-                const url = window.URL.createObjectURL(pdfBlob);
-
-                // Create a temporary <a> element to trigger the download
-                const tempLink = document.createElement("a");
-                tempLink.href = url;
-                tempLink.setAttribute("download", downloadFileName.value);
-
-                tempLink.click();
-
-                window.URL.revokeObjectURL(url);
+            await downloadS3File(res);
         }
         catch(e){
             useLogger().error(e, `${t('pdfError')}`)
@@ -140,6 +125,29 @@
         }
     }
 
+    async function downloadS3File(res){
+        let buffer;
+        if(res.url){
+            // Create a Blob from the response data
+            buffer = await fetch(res.url).then(r => r.arrayBuffer());            
+        }
+        else{
+            buffer = await res.arrayBuffer();
+        }
+        const pdfBlob = new Blob([buffer], { type: "application/pdf" });
+        // Create a temporary URL for the Blob
+        const downloadUrl = window.URL.createObjectURL(pdfBlob);
+
+        // Create a temporary <a> element to trigger the download
+        const tempLink = document.createElement("a");
+        tempLink.href = downloadUrl;
+        tempLink.setAttribute("download", downloadFileName.value);
+
+        tempLink.click();
+
+        window.URL.revokeObjectURL(downloadUrl);
+        
+    }
     defineExpose({
         pdfDocument : onPdfDocument
     });

--- a/components/common/pdf-section.vue
+++ b/components/common/pdf-section.vue
@@ -70,7 +70,7 @@
             importCSS:true,
             importStyle : true,
             // pageTitle : $('title').text(),
-            // loadCSS : '/app/css/pdf-friendly.css',
+            loadCSS : '/app/css/print-friendly.css',
         });	
         // console.log(html);
         try{

--- a/components/common/view-actions.vue
+++ b/components/common/view-actions.vue
@@ -2,7 +2,8 @@
    <div class="row">
         <div class="col-12 mb-1">
             <pdf-section  class="me-md-2 btn-secondary float-end" :element="printSelector" :title="title" ref="pdfSectionRef" 
-                @on-pdf-document="onPdfDocument" @on-after-pdf="onAfterPdf"></pdf-section>
+                @on-pdf-document="onPdfDocument" @on-after-pdf="onAfterPdf" 
+                :save-to-storage="saveToStorage" :file-name="fileName"></pdf-section>
             <print-section  class="me-md-2 btn-secondary float-end" :element="printSelector" :title="title" ref="printSectionRef" 
                 @on-print-document="onPrintDocument" @on-before-print="onBeforePrint" @on-after-print="onAfterPrint"></print-section>
         </div>
@@ -19,6 +20,7 @@
         printSelector : {type: String, required:true},
         title   : {type: String, required:true},
         fileName: {type: String, required:true},
+        saveToStorage: {type: Boolean, default:false},
     });
 
     defineExpose({

--- a/pages/national-reports/nr7/[identifier].vue
+++ b/pages/national-reports/nr7/[identifier].vue
@@ -2,7 +2,8 @@
     <km-suspense>
       <view-actions print-selector=".nr7-section-view" :title="lstring(record?.workingDocumentTitle||record?.title, locale)"
           ref="viewActionsRef" @on-print-document="onPrintDocument" @on-before-print="onBeforePrint"
-          @on-after-print="onAfterPrint" @on-pdf-document="onPdfDocument" @on-after-pdf="onAfterPdf"></view-actions>
+          @on-after-print="onAfterPrint" @on-pdf-document="onPdfDocument" @on-after-pdf="onAfterPdf"
+          :save-to-storage="true" :file-name="downloadFileName"></view-actions>
 
       <workflow-request v-if="workflowId" :workflow-id="workflowId"></workflow-request>
 
@@ -28,6 +29,10 @@
     breadcrumbs : {
       skip : ['identifier']
     }
+  });
+
+  const downloadFileName = computed(()=>{
+    return `nr7-${record.value?.body?.government?.identifier}-${record.value?.documentID}-${record.value?.revision}.pdf`;
   });
 
   const onDocumentLoad = (document)=>{

--- a/styles/print-friendly.css
+++ b/styles/print-friendly.css
@@ -1,4 +1,17 @@
-﻿@media print {
+﻿/* Specify font for Prince */
+body {
+    font-family: 
+        "Noto Sans CJK SC",      /* Chinese (Simplified) */
+        "Noto Sans CJK TC",      /* Chinese (Traditional) */
+        "Noto Sans Arabic",      /* Arabic */
+        "Noto Sans",             /* English, French, Spanish */
+        "KacstOne",              /* Arabic fallback */
+        "WenQuanYi Zen Hei",     /* Chinese fallback */
+        sans-serif;
+}
+
+@media print {
+    
     a[href]:after {
         content: '' !important;
     }


### PR DESCRIPTION
Enhances the PDF generation process by implementing a caching mechanism using S3.

- **Implements S3 PDF caching and retrieval:**
    - Introduces a `saveToStorage` prop in the `pdf-section` component to control caching.
    - Before generating a new PDF, verifies if a corresponding PDF already exists in an S3 bucket for the current realm.
    - If a PDF is found on S3, it directly opens the cached version, skipping regeneration.
    - Passes the `saveToStorage` flag to the backend PDF generation service to manage document persistence.
- **Improves multi-language PDF rendering:**
    - Adds a comprehensive list of multi-language font families to `print-friendly.css` to ensure correct display of various scripts in generated PDFs.
- **Applies to National Reports:**
    - Configures NR7 reports to leverage the new S3 PDF caching feature, including dynamic filename generation for unique identification.